### PR TITLE
Update tooltip on roominfo

### DIFF
--- a/src/components/Room.vue
+++ b/src/components/Room.vue
@@ -38,7 +38,7 @@ export default {
         .map(({ playerName }) => playerName)
         .join(", ");
       return `${players} ${
-        this.room.nodes.length > 1 ? "plays together at" : "plays at"
+        this.room.nodes.length > 1 ? "are playing" : "is playing"
       } ${this.gameName}`;
     }
   }


### PR DESCRIPTION
For multiple people you would say: people are playing gamename
Even better would be: Person1, Person2 and Person3 are playing gamename.
This means after each person there is a ',' and between the last 2 it should be 'and'
I didn't know how to do that.

For 1 person you would say: person is playing gamename