### PR TITLE
Update Download.vue

### DIFF
--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -40,40 +40,14 @@
     </p>
     <h2>Switch Sysmodule and Homebrew (ldn_mitm)</h2>
     <p>
-      For atmosphere 14:
+      For the ldn_mitm compatibility list and links, please visit below
       <a
-        href="https://github.com/spacemeowx2/ldn_mitm/releases/download/v1.5.0/ldn_mitm_v1.5.0.zip"
+        href="https://github.com/spacemeowx2/ldn_mitm#version-table"
         target="=_blank"
         rel="noreferrer noopener"
-        >ldn_mitm v1.5.0</a
       >
-    </p>
-    <p>
-      For atmosphere 13:
-      <a
-        href="https://github.com/spacemeowx2/ldn_mitm/releases/download/v1.4.0/ldn_mitm_v1.4.0.zip"
-        target="=_blank"
-        rel="noreferrer noopener"
-        >ldn_mitm v1.4.0</a
-      >
-    </p>
-    <p>
-      For atmosphere 11 or 12:
-      <a
-        href="https://github.com/spacemeowx2/ldn_mitm/releases/download/v1.3.4/ldn_mitm_v1.3.4.zip"
-        target="=_blank"
-        rel="noreferrer noopener"
-        >ldn_mitm v1.3.4</a
-      >
-    </p>
-    <p>
-      For atmosphere 10:
-      <a
-        href="https://github.com/spacemeowx2/ldn_mitm/releases/download/v1.3.3/ldn_mitm_v1.3.3.zip"
-        target="=_blank"
-        rel="noreferrer noopener"
-        >ldn_mitm v1.3.3</a
-      >
+      https://github.com/spacemeowx2/ldn_mitm#version-table
+      </a>
     </p>
     <em>(or you can use SX-OS v2.9.5+)</em>
   </div>


### PR DESCRIPTION
removed individual links/versions and linked to the readme.md version-table from the ldn_mitm github. a recent PR on ldn_mitm now links to each version of ldn_mitm with info shown for which AMS will work with it. This should clean this page up a bit while also showing up to date compatibility information.