### PR TITLE
Add lan-play download link on install page

### DIFF
--- a/src/components/Install.vue
+++ b/src/components/Install.vue
@@ -11,7 +11,15 @@
       WinPcap
     </a>
   </p>
-  <p>Then run <code>lan-play-win64.exe</code> as an administrator.</p>
+  <p>
+    Then run
+    <a
+      href="https://github.com/spacemeowx2/switch-lan-play/releases/download/v0.2.3/lan-play-win64.exe"
+      target="=_blank"
+      rel="noreferrer noopener"
+    >
+      lan-play-win64.exe</a> as an administrator
+  </p>
   <h3>MacOS</h3>
   <p>
     First, you need to install

--- a/src/utils/rooms.js
+++ b/src/utils/rooms.js
@@ -37,9 +37,7 @@ const AdvertiseDataMap = _gameId => {
     // MONSTER HUNTER RISE
     case "0100b04011742000":
       return data => {
-        const locked = data
-          .split("000000000400")[0] // delimiter
-          ?.endsWith("0831003100310031"); // locked
+        const locked = data.split("0000000400")[0]?.length > 44; // 44: unlocked ; 60: locked
         return {
           locked
         };
@@ -76,7 +74,7 @@ const sanitizeData = _room => {
       // DRAGON BALL FighterZ
       _room.contentId = "0100a250097f0000";
     } else {
-      let data = _room.advertiseData.split("000000000400");
+      let data = _room.advertiseData.split("0000000400");
       if (data.length === 4) {
         // MONSTER HUNTER RISE
         _room.contentId = "0100b04011742000";


### PR DESCRIPTION
Many users in the #help channel of the slp discord state that they can't find lan-play-win64.exe after installing WinPcap.
This helps to clarify that lan-play is a different thing than WinPcap.