### PR TITLE
fix lan mode combination for pokken tournament

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -145,7 +145,7 @@
       "Mario Tennis Aces": "Select Free Play from the Main Menu. Press [Left Analog (hold down)] and press [L] + [R].",
       "Pokémon Shield": "Press [L] + [R] + [Left Analog] in the options menu.",
       "Pokémon Sword": "Press [L] + [R] + [Left Analog] in the options menu.",
-      "Pokkén Tournament DX": "From the main screen select a game. Press [X] + [Dpad-Down] and press [L] + [R].",
+      "Pokkén Tournament DX": "From the main screen select a game. Press [B] + [X] + [Dpad-Down] and press [L] + [R].",
       "Splatoon 2": "Press [L] + [R] + [Left Analog] at the local play option. Hold down until the lan mode is activated."
     }
   },


### PR DESCRIPTION
The currently displayed combination is missing the B key