### PR TITLE
Fix whitespace in server hostname

### DIFF
--- a/public/data/servers.json
+++ b/public/data/servers.json
@@ -189,7 +189,7 @@
     "type": "rust"
   },
   {
-    "ip": " games.initlab.org",
+    "ip": "games.initlab.org",
     "port": 11451,
     "flag": "bg",
     "platform": "switch",


### PR DESCRIPTION
a whitespace is preventing the server from being polled on the status page, and causes the error:
app.b4aecb24.js:1 WebSocket connection to 'ws://%20games.initlab.org:11451/' failed: