### PR TITLE
scarlet/violet

### DIFF
--- a/src/data/games-switch-cfw.json
+++ b/src/data/games-switch-cfw.json
@@ -99,6 +99,14 @@
   { "title": "PixARK" },
   { "title": "Poisoft Thud Card", "ds": true },
   { "title": "Pokémon: Legends Arceus", "lang": "EN" },
+  {
+    "title": "Pokémon Scarlet",
+    "source": "https://assets.nintendo.eu/image/upload/f_auto/q_auto/v1/MNS/NOE/70010000053967/1.1_ProductTile_Switch_PokemonScarlet_KeyArt_enNOE"
+  },
+  {
+    "title": "Pokémon Violet",
+    "source": "https://assets.nintendo.eu/image/upload/f_auto/q_auto/v1/MNS/NOE/70010000053972/1.1_ProductTile_Switch_PokemonViolet_KeyArt_enNOE"
+  },
   { "title": "Portal Knights" },
   {
     "title": "Pro Yakyuu Famista Evolution (JP)",

--- a/src/data/games-switch-ofw.json
+++ b/src/data/games-switch-ofw.json
@@ -7,24 +7,12 @@
   { "title": "Mario Kart 8 Deluxe" },
   { "title": "Mario Tennis Aces" },
   {
-    "title": "Pokémon Legends: Arceus",
-    "lang": "EN"
-  },
-  {
-    "title": "Pokémon Scarlet",
-    "source": "https://assets.nintendo.eu/image/upload/f_auto/q_auto/v1/MNS/NOE/70010000053967/1.1_ProductTile_Switch_PokemonScarlet_KeyArt_enNOE"
-  },
-  {
     "title": "Pokémon Shield",
     "lang": "enGB"
   },
   {
     "title": "Pokémon Sword",
     "lang": "enGB"
-  },
-  {
-    "title": "Pokémon Violet",
-    "source": "https://assets.nintendo.eu/image/upload/f_auto/q_auto/v1/MNS/NOE/70010000053972/1.1_ProductTile_Switch_PokemonViolet_KeyArt_enNOE"
   },
   { "title": "Pokkén Tournament DX" },
   { "title": "SAINTS ROW: THE THIRD - THE FULL PACKAGE" },


### PR DESCRIPTION
Pokemon Arceus, Scarlet, and Violet were erroneously added to the ofw game list. This PR removes them from the OFW list and moves them to CFW. In the case of Arceus, it was already present on the CFW list so it's only removed from OFW. 