### PR TITLE
Rename trey.ddns.net to switch.exabytes.space

### DIFF
--- a/public/data/servers.json
+++ b/public/data/servers.json
@@ -28,7 +28,7 @@
     "type": "rust"
   },
   {
-    "ip": "trey.ddns.net",
+    "ip": "switch.exabytes.space",
     "port": 11451,
     "flag": "us",
     "platform": "switch",


### PR DESCRIPTION
Goodbye no-ip.com, hello Cloudflare